### PR TITLE
Use correct prefix for multik_reads.fa file

### DIFF
--- a/utils/multik
+++ b/utils/multik
@@ -36,6 +36,7 @@ then
     max_k=$(LC_NUMERIC="en_US.UTF-8" printf "%.0f" $(echo 0.95*$avg_readlen*$density | bc))
 fi
 
+set -e # abort if any program fails
 echo "avg readlen: $avg_readlen, max k: $max_k"
 
 function assemble {

--- a/utils/multik
+++ b/utils/multik
@@ -68,10 +68,10 @@ fi
 last_k=5
 for k in $(seq $start_k 5 $max_k)
 do
-    zcat -f $tprefix.msimpl.fa $tprefix.msimpl.fa |seqtk seq -A -L 100000 > multik_reads.fa
-    zcat -f $reads  |seqtk seq -A >> multik_reads.fa
+    zcat -f $tprefix.msimpl.fa $tprefix.msimpl.fa |seqtk seq -A -L 100000 > $prefix.multik_reads.fa
+    zcat -f $reads  |seqtk seq -A >> $prefix.multik_reads.fa
     tprefix=$prefix-k$k
-    assemble $PWD/multik_reads.fa $k $l $density $tprefix $threads $DIR
+    assemble $prefix.multik_reads.fa $k $l $density $tprefix $threads $DIR
     last_k=$k
     rm -f *.sequences
 done


### PR DESCRIPTION
I now finally figured out what caused the weird problems in #20 and #21.

I have executed mdbg in a cluster environment with a shared file system. Unfortunately, the multik_reads.fa file was always stored in the working directory of the processes, which was the same for all of them. This caused the file to become corrupted, i.e. contain fasta-headers within the sequence parts.

In this pull request, I made the multik_fasta.fa file use the same prefix as the rest of the files. Additionally I added `set -e` before starting the assembly such that the script does not swallow errors in the assembler.

Closes #20